### PR TITLE
refactor: misc

### DIFF
--- a/terminal_commander.cpp
+++ b/terminal_commander.cpp
@@ -25,6 +25,26 @@ int strcmp(const char *s1, const char *s2) {
   return 0;
 }
 
+int tolower(int c) {
+  return c >= 'A' && c <= 'Z' ? c + 32 : c;
+}
+
+int strncasecmp(const char *s1, const char *s2, size_t num) {
+  const unsigned char *p1 = (const unsigned char *)s1;
+  const unsigned char *p2 = (const unsigned char *)s2;
+
+	if (num == 0) return 0;
+
+	while (num-- != 0 && tolower(*p1) == tolower(*p2)) {
+		if (num == 0 || *p1 == '\0' || *p2 == '\0')
+			break;
+		p1++;
+		p2++;
+	}
+
+	return tolower(*p1) - tolower(*p2);
+}
+
 namespace TerminalCommander {
   using namespace TerminalCommanderTypes;
 
@@ -169,9 +189,7 @@ namespace TerminalCommander {
     }
     this->command.argsLength = data_index - this->command.cmdLength;
 
-    if ((this->command.data[0] == 'i' || this->command.data[0] == 'I') &&
-        (this->command.data[1] == '2' || this->command.data[1] == '@') &&
-        (this->command.data[2] == 'c' || this->command.data[2] == 'C')) {
+    if (strncasecmp(this->command.data, "I2C", 3)) {
 
       // test if buffer represents hex value pairs and convert these from ASCII to hex
       if (!this->parseTwoWireData()) {
@@ -199,10 +217,7 @@ namespace TerminalCommander {
         return;
       }
     }
-    else if ((this->command.data[0] == 's' || this->command.data[0] == 'S') &&
-             (this->command.data[1] == 'c' || this->command.data[1] == 'C') &&
-             (this->command.data[2] == 'a' || this->command.data[2] == 'A') &&
-             (this->command.data[3] == 'n' || this->command.data[3] == 'N')) {
+    if (strncasecmp(this->command.data, "SCAN", 4)) {
       this->command.protocol = I2C_SCAN;
     }
 

--- a/terminal_commander.cpp
+++ b/terminal_commander.cpp
@@ -100,7 +100,7 @@ namespace TerminalCommander {
           break;
         }
       }
-      writeErrorMsgToSerialBuffer(this->lastError.set(InvalidSerialCmdLength), this->lastError.message);
+      this->writeErrorMsgToSerialBuffer(this->lastError.set(InvalidSerialCmdLength), this->lastError.message);
       this->pSerial->println(this->lastError.message);
       this->lastError.clear();
       this->command.reset();
@@ -139,7 +139,7 @@ namespace TerminalCommander {
           // end of serial input data has been reached
           if (data_index == 0) {
             // input serial buffer is empty
-            writeErrorMsgToSerialBuffer(this->lastError.set(NoInput), this->lastError.message);
+            this->writeErrorMsgToSerialBuffer(this->lastError.set(NoInput), this->lastError.message);
             return;
           }
 
@@ -297,7 +297,7 @@ namespace TerminalCommander {
       // Scan TwoWire bus to explore and query available devices
       case I2C_SCAN: {
         if (this->command.argsLength != 0) {
-          writeErrorMsgToSerialBuffer(this->lastError.set(UnrecognizedProtocol), this->lastError.message);
+          this->writeErrorMsgToSerialBuffer(this->lastError.set(UnrecognizedProtocol), this->lastError.message);
           return;
         }
 
@@ -348,7 +348,7 @@ namespace TerminalCommander {
         }
 
         // no terminal commander or user-defined command was identified
-        writeErrorMsgToSerialBuffer(this->lastError.set(UnrecognizedProtocol), this->lastError.message);
+        this->writeErrorMsgToSerialBuffer(this->lastError.set(UnrecognizedProtocol), this->lastError.message);
       }
       break;
     }
@@ -388,14 +388,14 @@ namespace TerminalCommander {
       }
       else {
         // an input buffer value was unrecognized
-        writeErrorMsgToSerialBuffer(this->lastError.set(UnrecognizedInput), this->lastError.message);
+        this->writeErrorMsgToSerialBuffer(this->lastError.set(UnrecognizedInput), this->lastError.message);
         return false;
       }
     }
 
     if (idx == 0) {
       // input serial buffer is empty
-      writeErrorMsgToSerialBuffer(this->lastError.set(NoInput), this->lastError.message);
+      this->writeErrorMsgToSerialBuffer(this->lastError.set(NoInput), this->lastError.message);
       return false;
     }
 
@@ -511,6 +511,6 @@ namespace TerminalCommander {
   /// TODO: move as much of this as possible into an error_t member
   void TerminalCommander::writeErrorMsgToSerialBuffer(error_type_t error, char *message) {
     memset(message, '\0', TERM_ERROR_MESSAGE_SIZE);
-    strcpy_P(message, (char *)pgm_read_word(&(string_error_table[error])));
+    strcpy_P(message, (char *)pgm_read_word(&(this->string_error_table[error])));
   }
 }

--- a/terminal_commander.cpp
+++ b/terminal_commander.cpp
@@ -322,10 +322,9 @@ namespace TerminalCommander {
         this->i2cWrite();
         return;
       }
-      else {
-        this->writeErrorMsgToSerialBuffer(this->lastError.set(UnrecognizedI2CTransType), this->lastError.message);
-        return;
-      }
+
+      this->writeErrorMsgToSerialBuffer(this->lastError.set(UnrecognizedI2CTransType), this->lastError.message);
+      return;
     }
     else if (strncasecmp(this->command.data, "SCAN", 4)) {
       this->i2cScan();

--- a/terminal_commander.cpp
+++ b/terminal_commander.cpp
@@ -282,7 +282,7 @@ namespace TerminalCommander {
       this->serialCommandProcessor();
 
       if (this->lastError.flag) {
-        this->pSerial->print(this->lastError.message);
+        this->pSerial->println(this->lastError.message);
         this->lastError.clear();
       }
       this->pSerial->print(F(">> "));

--- a/terminal_commander.cpp
+++ b/terminal_commander.cpp
@@ -48,36 +48,6 @@ int strncasecmp(const char *s1, const char *s2, size_t num) {
 namespace TerminalCommander {
   using namespace TerminalCommanderTypes;
 
-  // put common error messages into Program memory to save SRAM space
-  static const char strErrNoError[] PROGMEM = "No Error\n";
-  static const char strErrNoInput[] PROGMEM = "Error: No Input\n";
-  static const char strErrUndefinedUserFunctionPtr[] PROGMEM = "Error: USER function is not defined (null pointer)\n";
-  static const char strErrUnrecognizedInput[] PROGMEM = "Error: Unrecognized Input Character\n";
-  static const char strErrInvalidSerialCmdLength[] PROGMEM = "\nError: Serial Command Length Exceeds Limit\n";
-  static const char strErrIncomingTwoWireReadLength[] PROGMEM = "Error: Incoming TwoWire Data Exceeds Read Buffer\n";
-  static const char strErrInvalidTwoWireCharacter[] PROGMEM = "Error: Invalid TwoWire Command Character\n";
-  static const char strErrInvalidTwoWireCmdLength[] PROGMEM = "Error: TwoWire Command requires Address and Register\n";
-  static const char strErrInvalidTwoWireWriteData[] PROGMEM = "Error: No data provided for write to I2C registers\n";
-  static const char strErrInvalidHexValuePair[] PROGMEM = "Error: Commands must be in hex value pairs\n";
-  static const char strErrUnrecognizedProtocol[] PROGMEM = "Error: Unrecognized Protocol\n";
-  static const char strErrUnrecognizedI2CTransType[] PROGMEM = "Error: Unrecognized I2C transaction type\n";
-
-  static const char *const string_error_table[] PROGMEM = 
-  {
-    strErrNoError,
-    strErrNoInput, 
-    strErrUndefinedUserFunctionPtr, 
-    strErrUnrecognizedInput, 
-    strErrInvalidSerialCmdLength, 
-    strErrIncomingTwoWireReadLength,
-    strErrInvalidTwoWireCharacter, 
-    strErrInvalidTwoWireCmdLength, 
-    strErrInvalidTwoWireWriteData, 
-    strErrInvalidHexValuePair, 
-    strErrUnrecognizedProtocol, 
-    strErrUnrecognizedI2CTransType
-  };
-
   /**
    * @brief Use this struct to build and config terminal command data.
    *
@@ -268,7 +238,7 @@ namespace TerminalCommander {
           break;
         }
       }
-      this->writeErrorMsgToSerialBuffer(this->lastError.set(InvalidSerialCmdLength), this->lastError.message);
+      this->lastError.set(InvalidSerialCmdLength);
       this->pSerial->println(this->lastError.message);
       this->lastError.clear();
     }
@@ -296,7 +266,7 @@ namespace TerminalCommander {
       return;
     }    
     if (!this->command.removeSpaces()) {
-      this->writeErrorMsgToSerialBuffer(this->lastError.set(NoInput), this->lastError.message);
+      this->lastError.set(NoInput);
       return;
     }
 
@@ -323,7 +293,7 @@ namespace TerminalCommander {
         return;
       }
 
-      this->writeErrorMsgToSerialBuffer(this->lastError.set(UnrecognizedI2CTransType), this->lastError.message);
+      this->lastError.set(UnrecognizedI2CTransType);
       return;
     }
     else if (strncasecmp(this->command.data, "SCAN", 4)) {
@@ -333,7 +303,7 @@ namespace TerminalCommander {
 
     if (!this->runUserCallbacks()) {
       // no terminal commander or user-defined command was identified
-      this->writeErrorMsgToSerialBuffer(this->lastError.set(UnrecognizedProtocol), this->lastError.message);
+      this->lastError.set(UnrecognizedProtocol);
     }
   }
 
@@ -371,14 +341,14 @@ namespace TerminalCommander {
       }
       else {
         // an input buffer value was unrecognized
-        this->writeErrorMsgToSerialBuffer(this->lastError.set(UnrecognizedInput), this->lastError.message);
+        this->lastError.set(UnrecognizedInput);
         return false;
       }
     }
 
     if (idx == 0) {
       // input serial buffer is empty
-      this->writeErrorMsgToSerialBuffer(this->lastError.set(NoInput), this->lastError.message);
+      this->lastError.set(NoInput);
       return false;
     }
 
@@ -412,19 +382,19 @@ namespace TerminalCommander {
       }
       else {
         // an command character is invalid or unrecognized
-        this->writeErrorMsgToSerialBuffer(this->lastError.set(InvalidTwoWireCharacter), this->lastError.message);
+        this->lastError.set(InvalidTwoWireCharacter);
         return false;
       }
     }
 
     if (idx < 7) {
       // command buffer is empty
-      this->writeErrorMsgToSerialBuffer(this->lastError.set(InvalidTwoWireCmdLength), this->lastError.message);
+      this->lastError.set(InvalidTwoWireCmdLength);
       return false;
     }
     else if ((idx >> 1) != ((idx + 1) >> 1)) {
       // command buffer does not specify hex values in multiples of 8 bits
-      this->writeErrorMsgToSerialBuffer(this->lastError.set(InvalidHexValuePair), this->lastError.message);
+      this->lastError.set(InvalidHexValuePair);
       return false;
     }
 
@@ -517,7 +487,7 @@ namespace TerminalCommander {
 
     while(this->pWire->available()) {
       if (twi_read_index >= TERM_TWOWIRE_BUFFER_SIZE) {
-        this->writeErrorMsgToSerialBuffer(this->lastError.set(IncomingTwoWireReadLength), this->lastError.message);
+        this->lastError.set(IncomingTwoWireReadLength);
         return;
       }
       this->command.twowire[twi_read_index] = (uint8_t)this->pWire->read();
@@ -544,7 +514,7 @@ namespace TerminalCommander {
 
   void TerminalCommander::i2cWrite(void) {
     if (this->command.argsLength < 6U) {
-      this->writeErrorMsgToSerialBuffer(this->lastError.set(InvalidTwoWireWriteData), this->lastError.message);
+      this->lastError.set(InvalidTwoWireWriteData);
       return;
     }
 
@@ -584,7 +554,7 @@ namespace TerminalCommander {
 
   void TerminalCommander::i2cScan(void) {
     if (this->command.argsLength != 0) {
-      this->writeErrorMsgToSerialBuffer(this->lastError.set(UnrecognizedProtocol), this->lastError.message);
+      this->lastError.set(UnrecognizedProtocol);
       return;
     }
 
@@ -628,11 +598,5 @@ namespace TerminalCommander {
       }
     }
     return false;
-  }
-
-  /// TODO: move as much of this as possible into an error_t member
-  void TerminalCommander::writeErrorMsgToSerialBuffer(error_type_t error, char *message) {
-    memset(message, '\0', TERM_ERROR_MESSAGE_SIZE);
-    strcpy_P(message, (char *)pgm_read_word(&(this->string_error_table[error])));
   }
 }

--- a/terminal_commander.cpp
+++ b/terminal_commander.cpp
@@ -7,7 +7,7 @@
 
 #include "terminal_commander.h"
 
-int16_t strcmp(const char *s1, const char *s2) {
+int strcmp(const char *s1, const char *s2) {
   const unsigned char *p1 = (const unsigned char *)s1;
   const unsigned char *p2 = (const unsigned char *)s2;
 

--- a/terminal_commander.cpp
+++ b/terminal_commander.cpp
@@ -263,14 +263,8 @@ namespace TerminalCommander {
 
     if (this->command.overflow) {
       // discard incoming data until the serial line ending is received
-      while(1) {
-        if (this->pSerial->available() > 0) {
-          char character = (char)this->pSerial->read();
-          if (character == TERM_LINE_ENDING) { 
-            break;
-          }
-        }
-        else {
+      while (this->pSerial->available() > 0) {
+        if ((char)this->pSerial->read() == TERM_LINE_ENDING) { 
           break;
         }
       }

--- a/terminal_commander.cpp
+++ b/terminal_commander.cpp
@@ -202,14 +202,16 @@ namespace TerminalCommander {
       }
 
       if (this->command.data[3] == 'r' || this->command.data[3] == 'R') {
-        this->command.protocol = I2C_READ;
+        this->i2cRead();
+        return;
       }
       else if (this->command.data[3] == 'w' || this->command.data[3] == 'W') {
         if (command.argsLength < 6U) {
           this->writeErrorMsgToSerialBuffer(this->lastError.set(InvalidTwoWireWriteData), this->lastError.message);
           return;
         }
-        this->command.protocol = I2C_WRITE;
+        this->i2cWrite();
+        return;
       }
       else {
         this->writeErrorMsgToSerialBuffer(this->lastError.set(UnrecognizedI2CTransType), this->lastError.message);
@@ -217,29 +219,13 @@ namespace TerminalCommander {
       }
     }
     else if (strncasecmp(this->command.data, "SCAN", 4)) {
-      this->command.protocol = I2C_SCAN;
+      this->i2cScan();
+      return;
     }
 
-    switch (command.protocol) {
-      case I2C_READ:
-        i2cRead();
-        break;
-
-      case I2C_WRITE:
-        i2cWrite();
-        break;
-
-      // Scan TwoWire bus to explore and query available devices
-      case I2C_SCAN:
-        i2cScan();
-        break;
-
-      default:
-        if (!runUserCallbacks()) {
-          // no terminal commander or user-defined command was identified
-          this->writeErrorMsgToSerialBuffer(this->lastError.set(UnrecognizedProtocol), this->lastError.message);
-        }
-        break;
+    if (!this->runUserCallbacks()) {
+      // no terminal commander or user-defined command was identified
+      this->writeErrorMsgToSerialBuffer(this->lastError.set(UnrecognizedProtocol), this->lastError.message);
     }
   }
 

--- a/terminal_commander.cpp
+++ b/terminal_commander.cpp
@@ -313,9 +313,11 @@ namespace TerminalCommander {
       }
 
       // if command was sent without spaces then set correct length for command and args
-      if (this->command.cmdLength == 0) {
+      // cmdLength will be length of command and args, e.g. I2CWffffff, and should be
+      // set to 4 and argsLength to (cmd+args).length - cmd.
+      if (this->command.cmdLength > 4U) {
+        this->command.argsLength = this->command.cmdLength - 4U;
         this->command.cmdLength = 4U;
-        this->command.argsLength = data_index - 4U;
       }
 
       if (this->command.data[3] == 'r' || this->command.data[3] == 'R') {

--- a/terminal_commander.cpp
+++ b/terminal_commander.cpp
@@ -502,14 +502,9 @@ namespace TerminalCommander {
       for (uint8_t k = 0; k < this->numUserCharCallbacks; k++) {
         if (strcmp(user_command, this->userCharCallbacks[k].command) == 0) {
           // remove leading whitespace
-          while (*this->command.pArgs != '\0'){
-            if (isSpace(this->command.pArgs[0])) {
-              this->command.pArgs++;
-              this->command.iArgs++;
-            }
-            else {
-              break;
-            }
+          while (*this->command.pArgs != '\0' && isSpace(this->command.pArgs[0])) {
+            this->command.pArgs++;
+            this->command.iArgs++;
           }
 
           // get char count for user args not including trailing whitespace/terminators

--- a/terminal_commander.cpp
+++ b/terminal_commander.cpp
@@ -217,7 +217,7 @@ namespace TerminalCommander {
         return;
       }
     }
-    if (strncasecmp(this->command.data, "SCAN", 4)) {
+    else if (strncasecmp(this->command.data, "SCAN", 4)) {
       this->command.protocol = I2C_SCAN;
     }
 

--- a/terminal_commander.h
+++ b/terminal_commander.h
@@ -43,7 +43,7 @@
    * @param  s2  Null-terminated byte string.
    * @return int 
    */
-  extern int16_t strcmp(const char *s1, const char *s2) __attribute__((weak));
+  extern int strcmp(const char *s1, const char *s2) __attribute__((weak));
 
   namespace TerminalCommander {
     namespace TerminalCommanderTypes {

--- a/terminal_commander.h
+++ b/terminal_commander.h
@@ -82,13 +82,6 @@
       // e.g. [&](){}, but requires #include <functional> which is not supported for AVR cores
       // typedef std::function<void(uint8_t)> cmd_callback_t
 
-      enum terminal_protocols_t {
-        UNDEFINED = 0,
-        I2C_READ, 
-        I2C_WRITE, 
-        I2C_SCAN, 
-      };
-
       enum error_type_t {
         NoError = 0,
         NoInput, 
@@ -196,9 +189,6 @@
         /** Fixed array for holding hex values to be sent/received via TwoWire/I2C */
         uint8_t twowire[TERM_TWOWIRE_BUFFER_SIZE] = {0};
 
-        /** Protocol type identified for  */
-        terminal_protocols_t protocol;
-
         /** Pointer to first non-space character following a space char in the incoming buffer */
         char *pArgs;
 
@@ -229,7 +219,6 @@
          * @returns Description of the returned parameter
          */
         terminal_command_t() :
-          protocol(UNDEFINED), 
           pArgs(nullptr),
           iArgs(0U), 
           cmdLength(0U), 
@@ -309,7 +298,6 @@
          * @returns void
          */
         void initialize(void) {
-          this->protocol    = UNDEFINED;
           this->pArgs       = nullptr;
           this->iArgs       = 0U;
           this->cmdLength   = 0U;

--- a/terminal_commander.h
+++ b/terminal_commander.h
@@ -45,6 +45,34 @@
    */
   extern int strcmp(const char *s1, const char *s2) __attribute__((weak));
 
+  /**
+   * @brief Convert a single ASCII character to its lowercase counterpart.
+   *
+   * @details Ignores characters outsize of A-Z.
+   * 
+   * @param  c  ASCII Character
+   * @return int
+   */
+  extern int tolower(int c) __attribute__((weak));
+
+  /**
+   * @brief Compares two null-terminated byte strings lexicographically,
+   *        limited to a maximum `num` characters. Case-insensitive.
+   *
+   * @details Returns:
+   *   Negative Value: If s1 appears before s2 in lexicographical order. Or, 
+   *                   the first not-matching character in s1 has a greater 
+   *                   ASCII value than the corresponding character in s2.
+   *             Zero: If s1 and s2 compare equal.
+   *   Positive Value: If s1 appears after s2 in lexicographical order. 
+   *
+   * @param  s1   Null-terminated byte string.
+   * @param  s2   Null-terminated byte string.
+   * @param  num  Maximum number of characters to compare.
+   * @return int 
+   */
+  extern int strncasecmp(const char *s1, const char *s2, size_t num) __attribute__((weak));
+
   namespace TerminalCommander {
     namespace TerminalCommanderTypes {
       // the following only works for lambda expressions that do NOT capture local variables, e.g. [](){}

--- a/terminal_commander.h
+++ b/terminal_commander.h
@@ -173,13 +173,10 @@
           memset(this->message,  '\0', sizeof(this->message));
         }
       };
+    };
 
-      /**
-       * @brief Use this struct to build and config terminal command data.
-       *
-       * @details A more elaborate description of the constructor.
-       */
-      struct terminal_command_t {
+    class Command {
+      public:
         /** Fixed array for raw incoming serial rx data */
         char serialRx[TERM_CHAR_BUFFER_SIZE + 1] = {'\0'};
 
@@ -218,14 +215,7 @@
          * @param   void
          * @returns Description of the returned parameter
          */
-        terminal_command_t() :
-          pArgs(nullptr),
-          iArgs(0U), 
-          cmdLength(0U), 
-          argsLength(0U), 
-          index(0U), 
-          complete(false), 
-          overflow(false) {}
+        Command();
 
         /**
          * @brief Use this struct to build and config terminal command data.
@@ -235,19 +225,7 @@
          * @param   param Description of the input parameter
          * @returns void
          */
-        void next(char character) {
-          if (character == TERM_LINE_ENDING) {
-            this->complete = true;
-            return;
-          } 
-          
-          if (index >= TERM_CHAR_BUFFER_SIZE) {
-            this->overflow = true;
-            return;
-          }
-          
-          serialRx[this->index++] = character;
-        }
+        void next(char character);
 
         /**
          * @brief Use this struct to build and config terminal command data.
@@ -257,11 +235,7 @@
          * @param   param Description of the input parameter
          * @returns void
          */
-        void previous(void) {
-          if (this->index > 0) {
-            serialRx[--this->index] = '\0';
-          }
-        }
+        void previous(void);
 
         /**
          * @brief Use this struct to build and config terminal command data.
@@ -271,11 +245,7 @@
          * @param   void
          * @returns void
          */
-        void flushInput(void) {
-          memset(this->serialRx,  '\0', sizeof(this->serialRx));
-          this->complete = false;
-          this->overflow = false;
-        }
+        void flushInput(void);
 
         /**
          * @brief Use this struct to build and config terminal command data.
@@ -285,9 +255,7 @@
          * @param   param Description of the input parameter
          * @returns void
          */
-        void flushTwoWire(void) {
-          memset(this->twowire, 0, sizeof(this->twowire));
-        }
+        void flushTwoWire(void);
 
         /**
          * @brief Use this struct to build and config terminal command data.
@@ -297,15 +265,7 @@
          * @param   void
          * @returns void
          */
-        void initialize(void) {
-          this->pArgs       = nullptr;
-          this->iArgs       = 0U;
-          this->cmdLength   = 0U;
-          this->argsLength  = 0U;
-          this->index       = 0U;
-          this->flushTwoWire();
-          memset(this->data, '\0', sizeof(this->data));
-        }
+        void initialize(void);
 
         /**
          * @brief Use this struct to build and config terminal command data.
@@ -315,12 +275,15 @@
          * @param   void
          * @returns void
          */
-        void reset(void) {
-          this->flushInput();
-          this->initialize();
-        }
-      };
-    }
+        void reset(void);
+
+        /**
+         * @brief Remove spaces from incoming serial command.
+         */
+        bool removeSpaces(void);
+
+      private:
+    };
 
     class TerminalCommander {
       public:
@@ -353,8 +316,16 @@
         uint8_t numUserCharCallbacks = 0;
 
         TerminalCommanderTypes::error_t lastError;
-        TerminalCommanderTypes::terminal_command_t command;
+
+        /**
+         * @brief Use this struct to build and config terminal command data.
+         *
+         * @details A more elaborate description of the constructor.
+         */
+        Command command;
+
         Stream *pSerial;
+
         TwoWire *pWire;
 
         /*! @brief  Execute incoming serial string by command or protocol type
@@ -427,5 +398,5 @@
         */
         void writeErrorMsgToSerialBuffer(TerminalCommanderTypes::error_type_t error, char *message);
     };
-  }
+  };
 #endif

--- a/terminal_commander.h
+++ b/terminal_commander.h
@@ -424,6 +424,12 @@
         */
         void scanTwoWireBus(void);
 
+
+        void i2cRead(void);
+        void i2cWrite(void);
+        void i2cScan(void);
+        bool runUserCallbacks(void);
+
         /*! @brief  Error-check the incoming ASCII command string
         *
         * @details Detailed description here.

--- a/terminal_commander.h
+++ b/terminal_commander.h
@@ -82,6 +82,36 @@
       // e.g. [&](){}, but requires #include <functional> which is not supported for AVR cores
       // typedef std::function<void(uint8_t)> cmd_callback_t
 
+      // put common error messages into Program memory to save SRAM space
+      static const char strErrNoError[] PROGMEM = "No Error\n";
+      static const char strErrNoInput[] PROGMEM = "Error: No Input\n";
+      static const char strErrUndefinedUserFunctionPtr[] PROGMEM = "Error: USER function is not defined (null pointer)\n";
+      static const char strErrUnrecognizedInput[] PROGMEM = "Error: Unrecognized Input Character\n";
+      static const char strErrInvalidSerialCmdLength[] PROGMEM = "\nError: Serial Command Length Exceeds Limit\n";
+      static const char strErrIncomingTwoWireReadLength[] PROGMEM = "Error: Incoming TwoWire Data Exceeds Read Buffer\n";
+      static const char strErrInvalidTwoWireCharacter[] PROGMEM = "Error: Invalid TwoWire Command Character\n";
+      static const char strErrInvalidTwoWireCmdLength[] PROGMEM = "Error: TwoWire Command requires Address and Register\n";
+      static const char strErrInvalidTwoWireWriteData[] PROGMEM = "Error: No data provided for write to I2C registers\n";
+      static const char strErrInvalidHexValuePair[] PROGMEM = "Error: Commands must be in hex value pairs\n";
+      static const char strErrUnrecognizedProtocol[] PROGMEM = "Error: Unrecognized Protocol\n";
+      static const char strErrUnrecognizedI2CTransType[] PROGMEM = "Error: Unrecognized I2C transaction type\n";
+
+      static const char *const string_error_table[] PROGMEM = 
+      {
+        strErrNoError,
+        strErrNoInput, 
+        strErrUndefinedUserFunctionPtr, 
+        strErrUnrecognizedInput, 
+        strErrInvalidSerialCmdLength, 
+        strErrIncomingTwoWireReadLength,
+        strErrInvalidTwoWireCharacter, 
+        strErrInvalidTwoWireCmdLength, 
+        strErrInvalidTwoWireWriteData, 
+        strErrInvalidHexValuePair, 
+        strErrUnrecognizedProtocol, 
+        strErrUnrecognizedI2CTransType
+      };
+
       enum error_type_t {
         NoError = 0,
         NoInput, 
@@ -143,6 +173,8 @@
         error_type_t set(error_type_t error_type) {
           this->flag = true;
           this->type = error_type;
+          memset(this->message, '\0', TERM_ERROR_MESSAGE_SIZE);
+          strcpy_P(this->message, (char *)pgm_read_word(&(string_error_table[error_type])));
           return this->type;
         }
 
@@ -388,15 +420,6 @@
         void i2cWrite(void);
         void i2cScan(void);
         bool runUserCallbacks(void);
-
-        /*! @brief  Error-check the incoming ASCII command string
-        *
-        * @details Detailed description here.
-        * 
-        * @param   param Description of the input parameter
-        * @returns void
-        */
-        void writeErrorMsgToSerialBuffer(TerminalCommanderTypes::error_type_t error, char *message);
     };
   };
 #endif


### PR DESCRIPTION
- when strcmp already exists, compiler throws error that int16_t is not int
- add [strncasecmp](https://linux.die.net/man/3/strncasecmp)
- split i2c and user commands into own functions
- simplify command type filtering logic
- refactor command struct to class
    - this makes more sense as this code doesn't need to be visible to end-user
    - if keeping this, my recommendation is to make properties private that can be
- fix i2c command/args length issue
    - if my understanding is correct, the end result of `removeSpaces` is that, in the case of `I2CWFFFFFF`, the `cmdLength` will be 10 and `argsLength` 0??
- simplify error setting
    - the `error_t` struct needs access to the PROGMEM strings
    - alternative approach: move `set()` fn outside of `error_t` struct