### PR TITLE
fix: term LED example not printing prompt on new line

### DIFF
--- a/examples/Terminal-LED-Control/Terminal-LED-Control.ino
+++ b/examples/Terminal-LED-Control/Terminal-LED-Control.ino
@@ -20,7 +20,8 @@ void setup() {
   pinMode(LED_BUILTIN, OUTPUT);
 
   // (optional) enable VT100-style terminal echo
-  Terminal.echo(false);
+  // set 'false' if using a terminal with local echo
+  Terminal.echo(true);
 
   // Option1: using a lambda expression that matches 
   // type TerminalCommander::user_callback_char_fn_t


### PR DESCRIPTION
This addresses Issue #3 

The example sketch has been updated to set terminal echo to 'true', since the default Arduino Serial Monitor behavior does not have local echo. This was a bug in the original example.

Changing TermComm to work around this would have created the following scenarios:
- Local Echo Disabled, Remote Echo Disabled -> terminal prompt prints on new line
- Local Echo Enabled, Remote Echo Disabled-> two newlines are printed (incorrect)

The assumption is that TermComm will always be used with local OR remote echo enabled. Having neither enabled is considered user error, in the same way that having both echos enabled is also user error.